### PR TITLE
Adds support for overloads and duplicate contracts.

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Takes in a solidity file and generatese a set of TypeScript classes for interacting with the contract.",
   "main": "output/index.js",
   "scripts": {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,18 +1,17 @@
 import { expect, use } from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 ;(use as Function)(chaiAsPromised)
-import { readFile as readFileCallback } from 'fs'
-import { promisify } from 'util'
+import { promises as fs } from 'fs'
 import { generateContractInterfaces } from '@zoltu/solidity-typescript-generator'
 import { Dependencies, Banana } from './test-data/event-output'
 
-const readFile = promisify(readFileCallback)
 describe('generateContractInterfaces', async () => {
 	async function testContractGeneration(prefix: string) {
-		const inputJson = await readFile(`./test-data/${prefix}-input.json`, { encoding: 'utf8' })
+		const inputJson = await fs.readFile(`./test-data/${prefix}-input.json`, { encoding: 'utf8' })
 		const input = JSON.parse(inputJson)
-		const expected = await readFile(`./test-data/${prefix}-output.ts`, { encoding: 'utf8' })
+		const expected = await fs.readFile(`./test-data/${prefix}-output.ts`, { encoding: 'utf8' })
 		const result = await generateContractInterfaces(input)
+		// await fs.writeFile(`./test-data/${prefix}-output.ts`, result)
 		expect(result).to.equal(expected)
 	}
 
@@ -36,8 +35,16 @@ describe('generateContractInterfaces', async () => {
 		await testContractGeneration('complex')
 	})
 
+	it(`generates duplicate contract`, async () => {
+		await testContractGeneration('duplicate-contracts')
+	})
+
 	it(`generates event`, async () => {
 		await testContractGeneration('event')
+	})
+
+	it(`generates excess event properties`, async () => {
+		await testContractGeneration('excess-event-properties')
 	})
 
 	it(`generates event duplicate`, async () => {
@@ -57,8 +64,8 @@ describe('generateContractInterfaces', async () => {
 	})
 
 	it(`errors on multiple unnamed returns`, async () => {
-		const inputJson = await readFile(`./test-data/error-multiple-unnamed-returns-input.json`, { encoding: 'utf8' })
-		const expected = await readFile(`./test-data/error-multiple-unnamed-returns-output.txt`, { encoding: 'utf8' })
+		const inputJson = await fs.readFile(`./test-data/error-multiple-unnamed-returns-input.json`, { encoding: 'utf8' })
+		const expected = await fs.readFile(`./test-data/error-multiple-unnamed-returns-output.txt`, { encoding: 'utf8' })
 		const input = JSON.parse(inputJson)
 		const resultPromise = generateContractInterfaces(input)
 		await expect(resultPromise).to.eventually.be.rejectedWith(expected)
@@ -96,9 +103,9 @@ describe('generateContractInterfaces', async () => {
 
 	// useful for doing one-off testing, set to skip so it doesn't run normally
 	it.skip(`sandbox`, async () => {
-		const inputJson = await readFile(`./test-data/event-input.json`, { encoding: 'utf8' })
+		const inputJson = await fs.readFile(`./test-data/event-input.json`, { encoding: 'utf8' })
 		const input = JSON.parse(inputJson)
-		const expected = await readFile(`./test-data/event-output.ts`, { encoding: 'utf8' })
+		const expected = await fs.readFile(`./test-data/event-output.ts`, { encoding: 'utf8' })
 		const result = generateContractInterfaces(input)
 		expect(result).to.equal(expected)
 	})

--- a/tests/test-data/duplicate-contracts-input.json
+++ b/tests/test-data/duplicate-contracts-input.json
@@ -1,0 +1,34 @@
+{
+	"contracts": {
+		"apple": {
+			"banana": {
+				"abi": [
+					{
+						"name": "cherry",
+						"type": "function",
+						"constant": true,
+						"payable": false,
+						"stateMutability": "pure",
+						"inputs": [],
+						"outputs": []
+					}
+				]
+			}
+		},
+		"durian": {
+			"banana": {
+				"abi": [
+					{
+						"name": "cherry",
+						"type": "function",
+						"constant": true,
+						"payable": false,
+						"stateMutability": "pure",
+						"inputs": [],
+						"outputs": []
+					}
+				]
+			}
+		}
+	}
+}

--- a/tests/test-data/duplicate-contracts-output.ts
+++ b/tests/test-data/duplicate-contracts-output.ts
@@ -13,22 +13,12 @@ export interface TransactionReceipt {
 }
 
 export const eventDescriptions: { [signatureHash: string]: EventDescription & {signature: string} } = {
-	'5c4cf109e00bf95f1fe07fc3173b24b6e8f94894407c6ec23c3e5fb82419a6ce': {"type":"event","name":"Durian","signature":"Durian(uint256,string,bytes,address)","inputs":[{"type":"uint256","name":"a","indexed":false},{"type":"string","name":"b","indexed":true},{"type":"bytes","name":"c","indexed":false},{"type":"address","name":"d","indexed":true}]}
+
 }
 
-export namespace Banana {
-	export interface Durian extends DecodedEvent {
-		name: 'Durian'
-		parameters: {
-			a: bigint
-			b: bigint
-			c: Uint8Array
-			d: bigint
-		}
-	}
-}
 
-export type Event = DecodedEvent | Banana.Durian
+
+export type Event = DecodedEvent
 
 
 export interface Dependencies {
@@ -72,21 +62,29 @@ export class Contract {
 }
 
 
-export class Banana extends Contract {
+export class banana extends Contract {
 	public constructor(dependencies: Dependencies, address: bigint) {
 		super(dependencies, address)
 	}
 
-	public cherry = async (attachedEth?: bigint): Promise<Array<Event>> => {
-		const methodSignature = 'cherry()' as const
-		const methodParameters = [] as const
-		return await this.remoteCall(methodSignature, methodParameters, { transactionName: 'cherry' }, attachedEth)
-	}
-
-	public cherry_ = async (attachedEth?: bigint): Promise<void> => {
+	public cherry_ = async (): Promise<void> => {
 		const methodSignature = 'cherry()' as const
 		const methodParameters = [] as const
 		const outputParameterDescriptions = [] as const
-		await this.localCall(methodSignature, outputParameterDescriptions, methodParameters, attachedEth)
+		await this.localCall(methodSignature, outputParameterDescriptions, methodParameters)
+	}
+}
+
+
+export class banana2 extends Contract {
+	public constructor(dependencies: Dependencies, address: bigint) {
+		super(dependencies, address)
+	}
+
+	public cherry_ = async (): Promise<void> => {
+		const methodSignature = 'cherry()' as const
+		const methodParameters = [] as const
+		const outputParameterDescriptions = [] as const
+		await this.localCall(methodSignature, outputParameterDescriptions, methodParameters)
 	}
 }

--- a/tests/test-data/duplicate-method-input.json
+++ b/tests/test-data/duplicate-method-input.json
@@ -1,0 +1,28 @@
+{
+	"contracts": {
+		"apple": {
+			"banana": {
+				"abi": [
+					{
+						"name": "cherry",
+						"type": "function",
+						"constant": true,
+						"payable": false,
+						"stateMutability": "pure",
+						"inputs": [],
+						"outputs": []
+					},
+					{
+						"name": "cherry",
+						"type": "function",
+						"constant": true,
+						"payable": false,
+						"stateMutability": "pure",
+						"inputs": [ { "name": "durian", "type": "uint256" } ],
+						"outputs": []
+					}
+				]
+			}
+		}
+	}
+}

--- a/tests/test-data/excess-event-properties-input.json
+++ b/tests/test-data/excess-event-properties-input.json
@@ -1,0 +1,38 @@
+{
+	"contracts": {
+		"Apple": {
+			"Banana": {
+				"abi": [
+					{
+						"anonymous": false,
+						"inputs": [
+							{
+								"indexed": false,
+								"name": "a",
+								"type": "uint256",
+								"internalType": "uint256"
+							},
+							{
+								"indexed": true,
+								"name": "b",
+								"type": "string"
+							},
+							{
+								"indexed": false,
+								"name": "c",
+								"type": "bytes"
+							},
+							{
+								"indexed": true,
+								"name": "d",
+								"type": "address"
+							}
+						],
+						"name": "Durian",
+						"type": "event"
+					}
+				]
+			}
+		}
+	}
+}

--- a/tests/test-data/excess-event-properties-output.ts
+++ b/tests/test-data/excess-event-properties-output.ts
@@ -77,16 +77,5 @@ export class Banana extends Contract {
 		super(dependencies, address)
 	}
 
-	public cherry = async (attachedEth?: bigint): Promise<Array<Event>> => {
-		const methodSignature = 'cherry()' as const
-		const methodParameters = [] as const
-		return await this.remoteCall(methodSignature, methodParameters, { transactionName: 'cherry' }, attachedEth)
-	}
 
-	public cherry_ = async (attachedEth?: bigint): Promise<void> => {
-		const methodSignature = 'cherry()' as const
-		const methodParameters = [] as const
-		const outputParameterDescriptions = [] as const
-		await this.localCall(methodSignature, outputParameterDescriptions, methodParameters, attachedEth)
-	}
 }


### PR DESCRIPTION
The handling of duplicate contracts and overloads is naive, the system just adds a number on the end of the contract/method name.  However, this solution is significantly better than not working.

Also fixes a bug with generated events which would result in non-compilable code if there were unexpected properties in the ABI.

Marked the parameters as readonly so it is more permissive in what it accepts.