### PR TITLE
Fixes a bug where tuple parameters couldn't be serialized and adds dependency implementations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/node_modules/
 **/output/
+**/output-es/
+**/output-cjs/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/solidity-typescript-generator.svg)](https://badge.fury.io/js/solidity-typescript-generator)
+[![npm version](https://badge.fury.io/js/@zoltu/solidity-typescript-generator.svg)](https://badge.fury.io/js/@zoltu/solidity-typescript-generator)
 
 Takes in the output JSON from `solc` and generatese a set of TypeScript classes for interacting with the contracts it references.
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,21 @@ Elsewhere in your project...
 ```typescript
 import { Apple } from '../generated/my-contract'
 
+// from @zoltu/solidity-typescript-generator-fetch-dependencies for use in browser
+const fetchBrowserDependencies = new FetchDependencies(new FetchJsonRpc('https://my-node.example.com:8545', window.fetch.bind(window)))
+// from @zoltu/solidity-typescript-generator-fetch-dependencies for use in NodeJS with node-fetch package off NPM
+const fetchNodeDependencies = new FetchDependencies(new FetchJsonRpc('https://my-node.example.com:8545', fetch))
+// from @zoltu/solidity-typescript-generator-browser-dependencies with no fallback
+const browserDependenciesWithoutFallback = new BrowserDependencies(undefined)
+const browserDependenciesWithFallback = new BrowserDependencies(fetchBrowserDependencies)
+// roll your own
 const dependencies = {
-	call(address: Address, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<Uint8Array> => { ... }
-	submitTransaction(address: Address, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<TransactionReceipt> => { ... }
+	call(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<Uint8Array> => {
+		// TODO: implement; make note of the type of `EncodableArray` (bigint, Uint8Array, string, booleans, object, and array)
+	}
+	submitTransaction(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<TransactionReceipt> => {
+		// TODO: implement; make note of the type of `TransactionReceipt` (needs to be deserialized from wire encoded JSON) expected by `Apple`
+	}
 }
 const apple = new Apple(dependencies, appleAddress)
 // leading underscore means do an off-chain call, not an on-chain transaction
@@ -31,7 +43,7 @@ console.log(result)
 // you can attach value as a last parameter, but only on functions that are payable
 const result = await apple._cherry(5n, 'hello', 5n)
 // no leading underscore is an on-chain contract call
-// addresses are just bigints, which means you can use a bigint hex literal!
+// addresses are just bigints, which means you can use a bigint literal!
 const events = await apple.transfer(0x2FCBaFb681a086103e3d97927d9cA9Af9f1EBD22n, 5n*10n**18n)
 // the result of an on-chain call is an array of decoded events that occurred during the call
 // every event referenced in the solc output file is strongly typed

--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,0 +1,117 @@
+{
+  "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@zoltu/ethereum-abi-encoder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
+      "integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+    },
+    "@zoltu/ethereum-crypto": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-crypto/-/ethereum-crypto-2.1.1.tgz",
+      "integrity": "sha512-+Nt58vcVtp93UO3ZWt9PvUGMVKbJ4qRwWcFOmu+LkwvjSpBy6X51+sMiNkzgIaYGo/YpWWZ4hZCvluDSngOxHw=="
+    },
+    "@zoltu/ethereum-types": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-types/-/ethereum-types-8.4.2.tgz",
+      "integrity": "sha512-mpKiiTuW/y5nJS03VJ3wXGlsjBynkpCot2Yo9gbdLtaHaEUwTIunbUFXxVS9Xk+LC0irs8F25X2X0QyPw3EVDw=="
+    },
+    "@zoltu/typescript-transformer-append-js-extension": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz",
+      "integrity": "sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "ts-node": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "ttypescript": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.10.tgz",
+      "integrity": "sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
+}

--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
-      "integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-5.0.0.tgz",
+      "integrity": "sha512-f8swZZ6t5ljliGdyRWQEnguIm+Phx6CKju+c7OmVyc8mYK3ONhqSualAJ2v5HNLMNqmzZRk9Cbg1dklfPzxdaQ=="
     },
     "@zoltu/ethereum-crypto": {
       "version": "2.1.1",

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
+  "version": "4.0.0",
   "description": "Ethereum enabled browser dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
@@ -12,7 +13,7 @@
     "require": "output-cjs/index.js"
   },
   "dependencies": {
-    "@zoltu/ethereum-abi-encoder": "4.0.0",
+    "@zoltu/ethereum-abi-encoder": "5.0.0",
     "@zoltu/ethereum-crypto": "2.1.1",
     "@zoltu/ethereum-types": "8.4.2"
   },
@@ -24,5 +25,10 @@
   },
   "scripts": {
     "build": "ttsc --project tsconfig-es.json && ttsc --project tsconfig-cjs.json"
-  }
+  },
+  "files": [
+    "source/",
+    "output-es/",
+    "output-cjs/"
+  ]
 }

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
+  "description": "Ethereum enabled browser dependencies for generated typescript classes.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
+  },
+  "license": "Unlicense",
+  "dependencies": {
+    "@zoltu/ethereum-abi-encoder": "4.0.0",
+    "@zoltu/ethereum-crypto": "2.1.1",
+    "@zoltu/ethereum-types": "8.4.2"
+  },
+  "devDependencies": {
+    "typescript": "3.9.3",
+    "ttypescript": "1.5.10",
+    "ts-node": "8.10.1",
+    "@zoltu/typescript-transformer-append-js-extension": "1.0.1"
+  },
+  "scripts": {
+    "build": "ttsc --project tsconfig.json"
+  }
+}

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -6,6 +6,11 @@
     "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
   },
   "license": "Unlicense",
+  "main": "output-cjs/index.js",
+  "exports": {
+    "import": "output-es/index.js",
+    "require": "output-cjs/index.js"
+  },
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": "4.0.0",
     "@zoltu/ethereum-crypto": "2.1.1",
@@ -18,6 +23,6 @@
     "@zoltu/typescript-transformer-append-js-extension": "1.0.1"
   },
   "scripts": {
-    "build": "ttsc --project tsconfig.json"
+    "build": "ttsc --project tsconfig-es.json && ttsc --project tsconfig-cjs.json"
   }
 }

--- a/browser-dependencies/source/index.ts
+++ b/browser-dependencies/source/index.ts
@@ -1,0 +1,210 @@
+import { encodeMethod, EncodableArray } from '@zoltu/ethereum-abi-encoder'
+import { keccak256 } from '@zoltu/ethereum-crypto'
+import { IOffChainTransaction, Rpc, IJsonRpcRequest, JsonRpcMethod, IJsonRpcSuccess } from '@zoltu/ethereum-types'
+
+export const NotEthereumBrowserErrorMessage = `Your browser does not appear to be Ethereum enabled.`
+
+export interface BrowserDependenciesOptions {
+	readonly gasLimitProvider?: (transaction: Omit<IOffChainTransaction, 'gasPrice'> & { gasPrice?: bigint }) => Promise<bigint>
+	readonly gasPriceInAttoethProvider?: () => Promise<bigint>
+}
+
+export class BrowserDependencies {
+	public constructor(
+		private readonly fallbackDependencies?: Dependencies,
+		private readonly options: BrowserDependenciesOptions = {},
+	) {}
+
+	public readonly call = async (to: bigint, methodSignature: string, parameters: EncodableArray, value: bigint): Promise<Uint8Array> => {
+		if (!this.isEthereumBrowser() && this.fallbackDependencies !== undefined) return await this.fallbackDependencies.call(to, methodSignature, parameters, value)
+		if (!this.isEthereumBrowser()) throw new Error(NotEthereumBrowserErrorMessage)
+
+		const from = await this.getPrimaryAccount() || 0n
+		const data = await encodeMethod(keccak256.hash, methodSignature, parameters)
+		const gasPrice = (this.options.gasPriceInAttoethProvider !== undefined) ? await this.options.gasPriceInAttoethProvider() : await this.ethGasPrice()
+		return await this.ethCall({ from, to, data, value, gasLimit: null, gasPrice })
+	}
+
+	public readonly submitTransaction = async (to: bigint, methodSignature: string, parameters: EncodableArray, value: bigint): Promise<TransactionReceipt> => {
+		if (!this.isEthereumBrowser() && this.fallbackDependencies !== undefined) return await this.fallbackDependencies.submitTransaction(to, methodSignature, parameters, value)
+		if (!this.isEthereumBrowser()) throw new Error(NotEthereumBrowserErrorMessage)
+
+		const from = await this.getPrimaryAccount() || 0n
+		const data = await encodeMethod(keccak256.hash, methodSignature, parameters)
+		const gasPrice = (this.options.gasPriceInAttoethProvider !== undefined) ? await this.options.gasPriceInAttoethProvider() : await this.ethGasPrice()
+
+		const gasEstimatingTransaction = { from, to, value, data, gasLimit: null, gasPrice }
+		const gasLimit = this.options.gasLimitProvider !== undefined ? await this.options.gasLimitProvider(gasEstimatingTransaction) : await this.ethEstimateGas(gasEstimatingTransaction)
+		const nonce = await this.ethGetTransactionCount(from)
+		const unsignedTransaction = { ...gasEstimatingTransaction, gasLimit, nonce }
+		const transactionHash = await this.ethSendTransaction(unsignedTransaction)
+		let receipt = await this.ethGetTransactionReceipt(transactionHash)
+		while (receipt === null || receipt.blockNumber === null) {
+			await sleep(1000)
+			receipt = await this.ethGetTransactionReceipt(transactionHash)
+		}
+		if (!receipt.status) throw new Error(`Transaction mined, but failed.`)
+		return receipt
+	}
+
+	private readonly request = async (method: string, params: unknown) => {
+		if (window.ethereum === undefined) throw new Error(NotEthereumBrowserErrorMessage)
+		if ('request' in window.ethereum) {
+			return await window.ethereum.request({ method, params })
+		} else if ('sendAsync' in window.ethereum) {
+			if (!Array.isArray(params)) throw new Error(`Legacy Ethereum browsers do not support non-array RPC parameters.  ${JSON.stringify(params)}`)
+			// we capture window.ethereum here to retain type narrowing since TS doesn't understand that the Promise callback function is executed immediately
+			const ethereum = window.ethereum
+			return new Promise((resolve, reject) => {
+				ethereum.sendAsync({ jsonrpc: '2.0', id: 0, method, params }, (error, result) => {
+					if (error) return reject(unknownErrorToJsonRpcError(error, { request: { method, params } }))
+					if (!isJsonRpcLike(result)) return reject(new Error(NotEthereumBrowserErrorMessage))
+					if ('error' in result) return reject(unknownErrorToJsonRpcError(result.error, { request: { method, params } }))
+					// https://github.com/MetaMask/metamask-extension/issues/7970
+					return resolve(result.result)
+				})
+			})
+		} else {
+			throw new Error(NotEthereumBrowserErrorMessage)
+		}
+	}
+
+	private readonly isEthereumBrowser = () => {
+		if (window.ethereum !== undefined) return true
+		if (window.web3 !== undefined) return true
+		return false
+	}
+
+	private readonly getPrimaryAccount = async (): Promise<bigint | undefined> => {
+		const accounts = await this.ethAccounts()
+		return (accounts.length === 0) ? undefined : accounts[0]
+
+	}
+
+	private readonly makeRequest = <
+		// https://github.com/microsoft/TypeScript/issues/32976 TRequestConstructor should be constrained to constructors that take a string|number|null first parameter
+		TRequestConstructor extends new (...args: any[]) => { wireEncode: () => IJsonRpcRequest<JsonRpcMethod, any[]> },
+		TResponseConstructor extends new (rawResponse: IJsonRpcSuccess<any>) => { result: any },
+		TRequest extends InstanceType<TRequestConstructor>,
+		TResponse extends InstanceType<TResponseConstructor>,
+		TResponseResult extends ResultType<TResponse>,
+	>(Request: TRequestConstructor, Response: TResponseConstructor) => async (...args: DropFirst<ConstructorParameters<TRequestConstructor>>): Promise<TResponseResult> => {
+		const request = new Request(0, ...args) as TRequest
+		const rawRequest = request.wireEncode() as RawRequestType<TRequest>
+		const rawResponse = await this.request(rawRequest.method, rawRequest.params) as PickFirst<ConstructorParameters<TResponseConstructor>>
+		const response = new Response(rawResponse) as TResponse
+		return response.result as TResponseResult
+	}
+	private readonly ethAccounts = this.makeRequest(Rpc.Eth.Accounts.Request, Rpc.Eth.Accounts.Response)
+	private readonly ethCall = this.makeRequest(Rpc.Eth.Call.Request, Rpc.Eth.Call.Response)
+	private readonly ethEstimateGas = this.makeRequest(Rpc.Eth.EstimateGas.Request, Rpc.Eth.EstimateGas.Response)
+	private readonly ethGasPrice = this.makeRequest(Rpc.Eth.GasPrice.Request, Rpc.Eth.GasPrice.Response)
+	private readonly ethGetTransactionReceipt = this.makeRequest(Rpc.Eth.GetTransactionReceipt.Request, Rpc.Eth.GetTransactionReceipt.Response)
+	private readonly ethGetTransactionCount = this.makeRequest(Rpc.Eth.GetTransactionCount.Request, Rpc.Eth.GetTransactionCount.Response)
+	private readonly ethSendTransaction = this.makeRequest(Rpc.Eth.SendTransaction.Request, Rpc.Eth.SendTransaction.Response)
+}
+
+
+/*
+Helpers
+ */
+
+function sleep(delayInMilliseconds: number) {
+	return new Promise<void>(resolve => setTimeout(resolve, delayInMilliseconds))
+}
+
+function isJsonRpcLike(maybe: unknown): maybe is { result: unknown } | { error: unknown} {
+	return typeof maybe === 'object' && maybe !== null && ('result' in maybe || 'error' in maybe)
+}
+
+function mergeIn(target: object, source: object) {
+	for (const key in source) {
+		const targetValue = (target as any)[key] as unknown
+		const sourceValue = (source as any)[key] as unknown
+		if (targetValue === undefined || targetValue === null) {
+			;(target as any)[key] = sourceValue
+		} else if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+			mergeIn(targetValue, sourceValue)
+		} else {
+			// drop source[key], don't want to override the target value
+		}
+	}
+	return target
+}
+
+function isPlainObject(maybe: unknown): maybe is object {
+	if (typeof maybe !== 'object') return false
+	if (maybe === null) return false
+	if (Array.isArray(maybe)) return false
+	// classes can get complicated so don't try to merge them.  What does it mean to merge two Promises or two Dates?
+	if (Object.getPrototypeOf(maybe) !== Object.prototype) return false
+	return true
+}
+
+function unknownErrorToJsonRpcError(error: unknown, extraData: object) {
+	if (error instanceof Error) {
+		const mutableError = error as unknown as Record<'code' | 'data', unknown>
+		mutableError.code = mutableError.code || -32603
+		mutableError.data = mutableError.data || extraData
+		if (isPlainObject(mutableError.data)) mergeIn(mutableError.data, extraData)
+		return error
+	}
+	// if someone threw something besides an Error, wrap it up in an error
+	return new JsonRpcError(-32603, `Unexpected thrown value.`, mergeIn({ error }, extraData))
+}
+
+export class JsonRpcError extends Error {
+	constructor(public readonly code: number, message: string, public readonly data?: object) {
+		super(message)
+		this.name = this.constructor.name
+	}
+}
+
+
+/*
+Expected shape of window.ethereum or window.web3
+ */
+
+declare global {
+	interface Ethereum1193 {
+		request(options: { readonly method: string, readonly params?: unknown }): Promise<unknown>
+	}
+	interface EthereumLegacy {
+		sendAsync(options: { jsonrpc: '2.0', id: number | string | null, method: string, params: readonly unknown[] }, callback: (error: unknown, response: unknown) => void): void
+	}
+	interface EthereumEnableable {
+		enable(): Promise<readonly string[]>
+	}
+	interface Window {
+		ethereum?: (Ethereum1193 | EthereumLegacy) & ({} | EthereumEnableable)
+		web3?: { currentProvider: EthereumLegacy }
+	}
+}
+
+
+/*
+These are copied from the generator output.
+ */
+
+ export interface Log {
+	readonly topics: ReadonlyArray<bigint>
+	readonly data: Uint8Array
+}
+export interface TransactionReceipt {
+	readonly status: boolean
+	readonly logs: Iterable<Log>
+}
+export interface Dependencies {
+	call(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<Uint8Array>
+	submitTransaction(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<TransactionReceipt>
+}
+
+
+/*
+Type helpers
+ */
+
+ type DropFirst<T extends any[]> = ((...t: T) => void) extends ((x: any, ...u: infer U) => void) ? U : never
+type PickFirst<T extends any[]> = ((...t: T) => void) extends ((x: infer U, ...u: any[]) => void) ? U : never
+type ResultType<T extends { result: unknown }> = T extends { result: infer R } ? R : never
+type RawRequestType<T extends { wireEncode: () => IJsonRpcRequest<JsonRpcMethod, unknown[]> }> = T extends { wireEncode: () => infer R } ? R : never

--- a/browser-dependencies/tsconfig-cjs.json
+++ b/browser-dependencies/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"outDir": "output-cjs",
+		"noEmit": false,
+	},
+}

--- a/browser-dependencies/tsconfig-es.json
+++ b/browser-dependencies/tsconfig-es.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "ES2015",
+		"outDir": "output-es",
+		"noEmit": false,
+	},
+}

--- a/browser-dependencies/tsconfig.json
+++ b/browser-dependencies/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "ES2015",
+		"target": "ES2020",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"inlineSources": true,
+		"declaration": true,
+		"noEmit": false,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"outDir": "output",
+		"rootDir": "source",
+		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ]
+	},
+	"include": [
+		"source/**/*.ts"
+	]
+}

--- a/browser-dependencies/tsconfig.json
+++ b/browser-dependencies/tsconfig.json
@@ -6,7 +6,6 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"declaration": true,
-		"noEmit": false,
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,

--- a/fetch-dependencies/README.md
+++ b/fetch-dependencies/README.md
@@ -1,0 +1,26 @@
+[![npm version](https://badge.fury.io/js/@zoltu/solidity-typescript-generator-fetch-dependencies.svg)](https://badge.fury.io/js/@zoltu/solidity-typescript-generator-fetch-dependencies)
+
+Dependencies for code generated with @zoltu/solidity-typescript-generator that use `fetch` under the hood.
+
+## Usage
+### Browser
+```ts
+import { FetchJsonRpc, FetchDependencies } from '@zoltu/solidity-typescript-generator-fetch-dependencies'
+import { MyContract } from './generated/my-contract.ts'
+
+const rpc = new FetchJsonRpc('https://my-node.example.com:8545', window.fetch.bind(window))
+const fetchBrowserDependencies = new FetchDependencies(rpc)
+const myContractAddress = 0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+const myContract = new MyContract(fetchBrowserDependencies, myContractAddress)
+```
+### NodeJS
+```ts
+import fetch from 'node-fetch'
+import { FetchJsonRpc, FetchDependencies } from '@zoltu/solidity-typescript-generator-fetch-dependencies'
+import { MyContract } from './generated/my-contract.ts'
+
+const rpc = new FetchJsonRpc('https://my-node.example.com:8545', fetch)
+const fetchBrowserDependencies = new FetchDependencies(rpc)
+const myContractAddress = 0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+const myContract = new MyContract(fetchBrowserDependencies, myContractAddress)
+```

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@zoltu/ethereum-abi-encoder": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
-			"integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-5.0.0.tgz",
+			"integrity": "sha512-f8swZZ6t5ljliGdyRWQEnguIm+Phx6CKju+c7OmVyc8mYK3ONhqSualAJ2v5HNLMNqmzZRk9Cbg1dklfPzxdaQ=="
 		},
 		"@zoltu/ethereum-crypto": {
 			"version": "2.1.1",

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,0 +1,125 @@
+{
+	"name": "@keydonix/solidity-typescript-generator-fetch-dependencies",
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@zoltu/ethereum-abi-encoder": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
+			"integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+		},
+		"@zoltu/ethereum-crypto": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-crypto/-/ethereum-crypto-2.1.1.tgz",
+			"integrity": "sha512-+Nt58vcVtp93UO3ZWt9PvUGMVKbJ4qRwWcFOmu+LkwvjSpBy6X51+sMiNkzgIaYGo/YpWWZ4hZCvluDSngOxHw=="
+		},
+		"@zoltu/ethereum-fetch-json-rpc": {
+			"version": "12.2.2",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-fetch-json-rpc/-/ethereum-fetch-json-rpc-12.2.2.tgz",
+			"integrity": "sha512-wdybfnJ7s7uM4Jo9RKhM1RP21K9g1zt0jc2sTAKDR/TpIE0ms/FAW6izcBFdSSwC/nguyYiv1odhrh4g5z+tlQ==",
+			"requires": {
+				"@zoltu/ethereum-types": "8.4.2"
+			}
+		},
+		"@zoltu/ethereum-types": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-types/-/ethereum-types-8.4.2.tgz",
+			"integrity": "sha512-mpKiiTuW/y5nJS03VJ3wXGlsjBynkpCot2Yo9gbdLtaHaEUwTIunbUFXxVS9Xk+LC0irs8F25X2X0QyPw3EVDw=="
+		},
+		"@zoltu/typescript-transformer-append-js-extension": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz",
+			"integrity": "sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==",
+			"dev": true
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"ts-node": {
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+			"integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			}
+		},
+		"ttypescript": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.10.tgz",
+			"integrity": "sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.9.0"
+			}
+		},
+		"typescript": {
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+			"integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
+		}
+	}
+}

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,7 +1,8 @@
 {
-	"name": "@keydonix/solidity-typescript-generator-fetch-dependencies",
-	"requires": true,
+	"name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@zoltu/ethereum-abi-encoder": {
 			"version": "4.0.0",

--- a/fetch-dependencies/package.json
+++ b/fetch-dependencies/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-  "version": "0.1.1",
+  "version": "4.0.0",
   "description": "Fetch dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
   },
+  "license": "Unlicense",
   "main": "output-cjs/index.js",
   "exports": {
     "import": "output-es/index.js",
     "require": "output-cjs/index.js"
   },
-  "license": "Unlicense",
   "dependencies": {
-    "@zoltu/ethereum-abi-encoder": "4.0.0",
+    "@zoltu/ethereum-abi-encoder": "5.0.0",
     "@zoltu/ethereum-crypto": "2.1.1",
     "@zoltu/ethereum-fetch-json-rpc": "12.2.2"
   },

--- a/fetch-dependencies/package.json
+++ b/fetch-dependencies/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
+  "description": "Fetch dependencies for generated typescript classes.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
+  },
+  "license": "Unlicense",
+  "dependencies": {
+    "@zoltu/ethereum-abi-encoder": "4.0.0",
+    "@zoltu/ethereum-crypto": "2.1.1",
+    "@zoltu/ethereum-fetch-json-rpc": "12.2.2"
+  },
+  "devDependencies": {
+    "typescript": "3.9.3",
+    "ttypescript": "1.5.10",
+    "ts-node": "8.10.1",
+    "@zoltu/typescript-transformer-append-js-extension": "1.0.1"
+  },
+  "scripts": {
+    "build": "ttsc --project tsconfig.json"
+  }
+}

--- a/fetch-dependencies/package.json
+++ b/fetch-dependencies/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
+  "version": "0.1.1",
   "description": "Fetch dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
+  },
+  "main": "output-cjs/index.js",
+  "exports": {
+    "import": "output-es/index.js",
+    "require": "output-cjs/index.js"
   },
   "license": "Unlicense",
   "dependencies": {
@@ -18,6 +24,11 @@
     "@zoltu/typescript-transformer-append-js-extension": "1.0.1"
   },
   "scripts": {
-    "build": "ttsc --project tsconfig.json"
-  }
+    "build": "ttsc --project tsconfig-es.json && ttsc --project tsconfig-cjs.json"
+  },
+  "files": [
+    "source/",
+    "output-es/",
+    "output-cjs/"
+  ]
 }

--- a/fetch-dependencies/source/index.js
+++ b/fetch-dependencies/source/index.js
@@ -1,0 +1,77 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+exports.__esModule = true;
+exports.FetchDependencies = exports.FetchJsonRpc = void 0;
+var ethereum_abi_encoder_1 = require("@zoltu/ethereum-abi-encoder");
+var ethereum_crypto_1 = require("@zoltu/ethereum-crypto");
+var ethereum_fetch_json_rpc_1 = require("@zoltu/ethereum-fetch-json-rpc");
+exports.FetchJsonRpc = ethereum_fetch_json_rpc_1.FetchJsonRpc;
+var FetchDependencies = /** @class */ (function () {
+    function FetchDependencies(rpc) {
+        var _this = this;
+        this.rpc = rpc;
+        this.call = function (to, methodSignature, parameters, value) { return __awaiter(_this, void 0, void 0, function () {
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _b = (_a = this.rpc).offChainContractCall;
+                        _c = { to: to };
+                        return [4 /*yield*/, ethereum_abi_encoder_1.encodeMethod(ethereum_crypto_1.keccak256.hash, methodSignature, parameters)];
+                    case 1: return [4 /*yield*/, _b.apply(_a, [(_c.data = _d.sent(), _c.value = value, _c)])];
+                    case 2: return [2 /*return*/, _d.sent()];
+                }
+            });
+        }); };
+        this.submitTransaction = function (to, methodSignature, parameters, value) { return __awaiter(_this, void 0, void 0, function () {
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _b = (_a = this.rpc).onChainContractCall;
+                        _c = { to: to };
+                        return [4 /*yield*/, ethereum_abi_encoder_1.encodeMethod(ethereum_crypto_1.keccak256.hash, methodSignature, parameters)];
+                    case 1: return [4 /*yield*/, _b.apply(_a, [(_c.data = _d.sent(), _c.value = value, _c)])];
+                    case 2: return [2 /*return*/, _d.sent()];
+                }
+            });
+        }); };
+    }
+    return FetchDependencies;
+}());
+exports.FetchDependencies = FetchDependencies;

--- a/fetch-dependencies/source/index.ts
+++ b/fetch-dependencies/source/index.ts
@@ -1,0 +1,34 @@
+import { encodeMethod, EncodableArray } from '@zoltu/ethereum-abi-encoder'
+import { keccak256 } from '@zoltu/ethereum-crypto'
+import { FetchJsonRpc } from '@zoltu/ethereum-fetch-json-rpc'
+
+export { FetchJsonRpc }
+
+export class FetchDependencies implements Dependencies {
+	public constructor(public readonly rpc: FetchJsonRpc) { }
+
+	public readonly call = async (to: bigint, methodSignature: string, parameters: EncodableArray, value: bigint): Promise<Uint8Array> => {
+		return await this.rpc.offChainContractCall({ to, data: await encodeMethod(keccak256.hash, methodSignature, parameters), value })
+	}
+
+	public readonly submitTransaction = async (to: bigint, methodSignature: string, parameters: EncodableArray, value: bigint): Promise<TransactionReceipt> => {
+		return await this.rpc.onChainContractCall({ to, data: await encodeMethod(keccak256.hash, methodSignature, parameters), value })
+	}
+}
+
+
+/*
+These are copied from the generator output.
+ */
+export interface Log {
+	readonly topics: ReadonlyArray<bigint>
+	readonly data: Uint8Array
+}
+export interface TransactionReceipt {
+	readonly status: boolean
+	readonly logs: Iterable<Log>
+}
+export interface Dependencies {
+	call(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<Uint8Array>
+	submitTransaction(address: bigint, methodSignature: string, methodParameters: EncodableArray, value: bigint): Promise<TransactionReceipt>
+}

--- a/fetch-dependencies/tsconfig-cjs.json
+++ b/fetch-dependencies/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"outDir": "output-cjs",
+		"noEmit": false,
+	},
+}

--- a/fetch-dependencies/tsconfig-es.json
+++ b/fetch-dependencies/tsconfig-es.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "ES2015",
+		"outDir": "output-es",
+		"noEmit": false,
+	},
+}

--- a/fetch-dependencies/tsconfig.json
+++ b/fetch-dependencies/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "ES2015",
+		"target": "ES2020",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"inlineSources": true,
+		"declaration": true,
+		"noEmit": false,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"outDir": "output",
+		"rootDir": "source",
+		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ]
+	},
+	"include": [
+		"source/**/*.ts"
+	]
+}

--- a/fetch-dependencies/tsconfig.json
+++ b/fetch-dependencies/tsconfig.json
@@ -6,7 +6,6 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"declaration": true,
-		"noEmit": false,
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
-      "integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-5.0.0.tgz",
+      "integrity": "sha512-f8swZZ6t5ljliGdyRWQEnguIm+Phx6CKju+c7OmVyc8mYK3ONhqSualAJ2v5HNLMNqmzZRk9Cbg1dklfPzxdaQ=="
     },
     "@zoltu/ethereum-crypto": {
       "version": "2.1.1",

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Takes in a solidity file and generatese a set of TypeScript classes for interacting with the contract.",
   "main": "output/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "typescript": "3.6.4"
   },
   "dependencies": {
-    "@zoltu/ethereum-abi-encoder": "4.0.0",
+    "@zoltu/ethereum-abi-encoder": "5.0.0",
     "@zoltu/ethereum-crypto": "2.1.1"
   }
 }

--- a/library/source/index.ts
+++ b/library/source/index.ts
@@ -1,4 +1,4 @@
-import { generateSignature, AbiDescription, EventDescription, FunctionDescription, ParameterDescription, EventParameterDescription } from '@zoltu/ethereum-abi-encoder'
+import { generateFullSignature, AbiDescription, EventDescription, FunctionDescription, ParameterDescription, EventParameterDescription } from '@zoltu/ethereum-abi-encoder'
 import { keccak256 } from '@zoltu/ethereum-crypto'
 
 type Abi = ReadonlyArray<AbiDescription>
@@ -176,7 +176,7 @@ ${
 function remoteMethodTemplate(functionName: string, abiFunction: FunctionDescription, errorContext: { contractName: string }) {
 	const argNames: string = toArgNameString(abiFunction)
 	const params: string = toParamsString(abiFunction, true, errorContext)
-	const methodSignature = generateSignature(abiFunction)
+	const methodSignature = generateFullSignature(abiFunction)
 	const separator = (abiFunction.inputs.length !== 0 && abiFunction.stateMutability === 'payable') ? ', ' : ''
 	const attachedEthInputParameter = (abiFunction.stateMutability === 'payable') ? 'attachedEth?: bigint' : ''
 	const attachedEthCallParameter = (abiFunction.stateMutability === 'payable') ? ', attachedEth' : ''
@@ -191,7 +191,7 @@ function localMethodTemplate(functionName: string, abiFunction: FunctionDescript
 	const outputs = abiFunction.outputs || []
 	const argNames: string = toArgNameString(abiFunction)
 	const params: string = toParamsString(abiFunction, true, errorContext)
-	const methodSignature = generateSignature(abiFunction)
+	const methodSignature = generateFullSignature(abiFunction)
 	const separator = (abiFunction.inputs.length !== 0 && (abiFunction.stateMutability === 'payable')) ? ', ' : ''
 	const attachedEthInputParameter = (abiFunction.stateMutability === 'payable') ? 'attachedEth?: bigint' : ''
 	const attachedEthCallParameter = (abiFunction.stateMutability === 'payable') ? ', attachedEth' : ''

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -30,15 +30,15 @@
       "dev": true
     },
     "@zoltu/ethereum-abi-encoder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-4.0.0.tgz",
-      "integrity": "sha512-lkAMZEze6mqTHgoX0fhSoqQGwcbqpVGeVNEH6IDRdb6ZM4JEZbTxazNa4ejcX8eQn9tFa8GMW+6GN7N9XcM3ng=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@zoltu/ethereum-abi-encoder/-/ethereum-abi-encoder-5.0.0.tgz",
+      "integrity": "sha512-f8swZZ6t5ljliGdyRWQEnguIm+Phx6CKju+c7OmVyc8mYK3ONhqSualAJ2v5HNLMNqmzZRk9Cbg1dklfPzxdaQ=="
     },
     "@zoltu/solidity-typescript-generator": {
       "version": "file:../library",
       "dev": true,
       "requires": {
-        "@zoltu/ethereum-abi-encoder": "4.0.0",
+        "@zoltu/ethereum-abi-encoder": "5.0.0",
         "@zoltu/ethereum-crypto": "2.1.1"
       },
       "dependencies": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -21,6 +21,6 @@
     "typescript": "3.6.4"
   },
   "dependencies": {
-    "@zoltu/ethereum-abi-encoder": "4.0.0"
+    "@zoltu/ethereum-abi-encoder": "5.0.0"
   }
 }

--- a/tests/test-data/4-output.ts
+++ b/tests/test-data/4-output.ts
@@ -72,13 +72,13 @@ export class banana extends Contract {
 	}
 
 	public cherry = async (durian: bigint, attachedEth?: bigint): Promise<Array<Event>> => {
-		const methodSignature = 'cherry(uint256)' as const
+		const methodSignature = 'cherry(uint256 durian)' as const
 		const methodParameters = [durian] as const
 		return await this.remoteCall(methodSignature, methodParameters, { transactionName: 'cherry' }, attachedEth)
 	}
 
 	public cherry_ = async (durian: bigint, attachedEth?: bigint): Promise<boolean> => {
-		const methodSignature = 'cherry(uint256)' as const
+		const methodSignature = 'cherry(uint256 durian)' as const
 		const methodParameters = [durian] as const
 		const outputParameterDescriptions = [{"name":"eggplant","type":"bool"}] as const
 		const result = await this.localCall(methodSignature, outputParameterDescriptions, methodParameters, attachedEth)

--- a/tests/test-data/complex-output.ts
+++ b/tests/test-data/complex-output.ts
@@ -72,13 +72,13 @@ export class Banana extends Contract {
 	}
 
 	public cherry = async (durian: ReadonlyArray<ReadonlyArray<{ readonly a: bigint, readonly b: bigint, readonly c: { readonly d: boolean }, readonly e: string }>>, attachedEth?: bigint): Promise<Array<Event>> => {
-		const methodSignature = 'cherry((uint40,uint32,(bool),string)[][5])' as const
+		const methodSignature = 'cherry((uint40 a, uint32 b, (bool d) c, string e)[][5] durian)' as const
 		const methodParameters = [durian] as const
 		return await this.remoteCall(methodSignature, methodParameters, { transactionName: 'cherry' }, attachedEth)
 	}
 
 	public cherry_ = async (durian: ReadonlyArray<ReadonlyArray<{ readonly a: bigint, readonly b: bigint, readonly c: { readonly d: boolean }, readonly e: string }>>, attachedEth?: bigint): Promise<Array<Array<{ a: bigint, b: bigint, c: { d: boolean }, e: string }>>> => {
-		const methodSignature = 'cherry((uint40,uint32,(bool),string)[][5])' as const
+		const methodSignature = 'cherry((uint40 a, uint32 b, (bool d) c, string e)[][5] durian)' as const
 		const methodParameters = [durian] as const
 		const outputParameterDescriptions = [{"components":[{"name":"a","type":"int40"},{"name":"b","type":"int32"},{"components":[{"name":"d","type":"bool"}],"name":"c","type":"tuple"},{"name":"e","type":"string"}],"name":"durian","type":"tuple[][5]"}] as const
 		const result = await this.localCall(methodSignature, outputParameterDescriptions, methodParameters, attachedEth)


### PR DESCRIPTION
Prior to this fix, the canonical signature was being passed to the call/send provider which meant that there were no parameter names present.  Since tuples are mapped to objects, this meant that the tuples could not be serialized since the generated code wanted an object for a tuple parameter rather than a list.  This is a major version bump because Dependency implementations potentially need to get the selector for a non-canonical function signature.

If you are using `@zoltu/ethereum-abi-encoder` this major version bump should be trivial as it already understands how to extract the selector from non-canonical signatures.

----

The new dependency implementations will be separate NPM packages, but the idea is that it simplifies utilizing the generated contracts in NodeJS or browser.