### PR TITLE
 Works around a bug in Nethermind while waiting for a fix.

### DIFF
--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "requires": true,
+  "version": "4.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": {
       "version": "5.0.0",

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Ethereum enabled browser dependencies for generated typescript classes.",
   "repository": {
     "type": "git",

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-	"version": "0.1.1",
+	"version": "4.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -15,17 +15,17 @@
 			"integrity": "sha512-+Nt58vcVtp93UO3ZWt9PvUGMVKbJ4qRwWcFOmu+LkwvjSpBy6X51+sMiNkzgIaYGo/YpWWZ4hZCvluDSngOxHw=="
 		},
 		"@zoltu/ethereum-fetch-json-rpc": {
-			"version": "12.2.2",
-			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-fetch-json-rpc/-/ethereum-fetch-json-rpc-12.2.2.tgz",
-			"integrity": "sha512-wdybfnJ7s7uM4Jo9RKhM1RP21K9g1zt0jc2sTAKDR/TpIE0ms/FAW6izcBFdSSwC/nguyYiv1odhrh4g5z+tlQ==",
+			"version": "12.2.3",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-fetch-json-rpc/-/ethereum-fetch-json-rpc-12.2.3.tgz",
+			"integrity": "sha512-mdXyAliqUePLEodquLh7oXL7y/YzLVXNmxXe1Bb/ZaIq5tNfvZtZMNmTyUZQw7JwL83mAOBsVP7KN0mDydUwcg==",
 			"requires": {
-				"@zoltu/ethereum-types": "8.4.2"
+				"@zoltu/ethereum-types": "8.4.3"
 			}
 		},
 		"@zoltu/ethereum-types": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-types/-/ethereum-types-8.4.2.tgz",
-			"integrity": "sha512-mpKiiTuW/y5nJS03VJ3wXGlsjBynkpCot2Yo9gbdLtaHaEUwTIunbUFXxVS9Xk+LC0irs8F25X2X0QyPw3EVDw=="
+			"version": "8.4.3",
+			"resolved": "https://registry.npmjs.org/@zoltu/ethereum-types/-/ethereum-types-8.4.3.tgz",
+			"integrity": "sha512-cZchAyAuZYaZxEpYfqcA3gMYF66UwAl9qhIwxRyedzwKySmMVysVwGBIPJ3cIHaT2lIkyNeOnleeY7KY5tIovA=="
 		},
 		"@zoltu/typescript-transformer-append-js-extension": {
 			"version": "1.0.1",

--- a/fetch-dependencies/package.json
+++ b/fetch-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Fetch dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": "5.0.0",
     "@zoltu/ethereum-crypto": "2.1.1",
-    "@zoltu/ethereum-fetch-json-rpc": "12.2.2"
+    "@zoltu/ethereum-fetch-json-rpc": "12.2.3"
   },
   "devDependencies": {
     "typescript": "3.9.3",

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Takes in a solidity file and generatese a set of TypeScript classes for interacting with the contract.",
   "main": "output/index.js",
   "scripts": {


### PR DESCRIPTION
Nethermind returns `null` instead of `0` when asking for a proof of a merkle-patricia node that is unset.  This change makes it so we default to `0` in that situation.