### PR TITLE
Fixes bugs in browser dependencies.

### DIFF
--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Ethereum enabled browser dependencies for generated typescript classes.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* If sendAsync is called with no parameters, fill in an empty array as some ethereum providers don't like a missing `params`.
* Some providers will return a JSON-RPC object to the sendAsync callback that has a `null` or `undefined` error.  We need to do both an `in` check as well as a `null`/`undefined` check before proceeding to reject as an error.
* Adds code for rejecting with a JSON-RPC error (previously would report unknown error).
* Minor type improvements (could still do way better with `makeRequest`).