### PR TITLE
Makes some of the very useful methods in browser dependencies public.

### DIFF
--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Ethereum enabled browser dependencies for generated typescript classes.",
   "repository": {
     "type": "git",

--- a/browser-dependencies/source/index.ts
+++ b/browser-dependencies/source/index.ts
@@ -47,7 +47,7 @@ export class BrowserDependencies {
 		return receipt
 	}
 
-	private readonly request = async (method: string, params: unknown) => {
+	public readonly request = async (method: string, params: unknown) => {
 		if (window.ethereum === undefined) throw new Error(NotEthereumBrowserErrorMessage)
 		if ('request' in window.ethereum) {
 			return await window.ethereum.request({ method, params })
@@ -69,13 +69,13 @@ export class BrowserDependencies {
 		}
 	}
 
-	private readonly isEthereumBrowser = () => {
+	public readonly isEthereumBrowser = () => {
 		if (window.ethereum !== undefined) return true
 		if (window.web3 !== undefined) return true
 		return false
 	}
 
-	private readonly getPrimaryAccount = async (): Promise<bigint | undefined> => {
+	public readonly getPrimaryAccount = async (): Promise<bigint | undefined> => {
 		const accounts = await this.ethAccounts()
 		return (accounts.length === 0) ? undefined : accounts[0]
 	}


### PR DESCRIPTION
This isn't meant to be a general purpose library for interfacing with Ethereum via a browser, but by exposing these three methods we can handle probably 95% of all dapps entirely with this library.