### PR TITLE
Updates to be compatible with NodeJS 14.

### DIFF
--- a/browser-dependencies/README.md
+++ b/browser-dependencies/README.md
@@ -1,0 +1,18 @@
+[![npm version](https://badge.fury.io/js/@zoltu/solidity-typescript-generator-browser-dependencies.svg)](https://badge.fury.io/js/@zoltu/solidity-typescript-generator-browser-dependencies)
+
+Dependencies for code generated with @zoltu/solidity-typescript-generator that uses `window.ethereum` provider under the hood.
+
+## Usage
+### Browser
+```ts
+import { FetchJsonRpc, FetchDependencies } from '@zoltu/solidity-typescript-generator-fetch-dependencies'
+import { BrowserDependencies } from '@zoltu/solidity-typescript-generator-browser-dependencies'
+import { MyContract } from './generated/my-contract.ts'
+
+// we use fetch to a centralized node as a fallabck if `window.ethereum` isn't available
+const rpc = new FetchJsonRpc('https://my-node.example.com:8545', window.fetch.bind(window))
+const fetchDependencies = new FetchDependencies(rpc)
+const browserDependencies = new BrowserDependencies(fetchDependencies, {})
+const myContractAddress = 0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+const myContract = new MyContract(browserDependencies, myContractAddress)
+```

--- a/browser-dependencies/package-lock.json
+++ b/browser-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/browser-dependencies/package.json
+++ b/browser-dependencies/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@zoltu/solidity-typescript-generator-browser-dependencies",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Ethereum enabled browser dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
   },
   "license": "Unlicense",
-  "main": "output-cjs/index.js",
+  "main": "./output-cjs/index.js",
   "exports": {
-    "import": "output-es/index.js",
-    "require": "output-cjs/index.js"
+    "import": "./output-es/index.js",
+    "require": "./output-cjs/index.js"
   },
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": "5.0.1",

--- a/browser-dependencies/tsconfig.json
+++ b/browser-dependencies/tsconfig.json
@@ -3,17 +3,18 @@
 		"module": "ES2015",
 		"target": "ES2020",
 		"moduleResolution": "node",
+		"rootDir": "source",
 		"sourceMap": true,
 		"inlineSources": true,
 		"declaration": true,
+		"declarationMap": true,
+		"noEmit": true,
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "output",
-		"rootDir": "source",
-		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ]
+		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ],
 	},
 	"include": [
 		"source/**/*.ts"

--- a/fetch-dependencies/package-lock.json
+++ b/fetch-dependencies/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-	"version": "5.0.1",
+	"version": "5.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/fetch-dependencies/package.json
+++ b/fetch-dependencies/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@zoltu/solidity-typescript-generator-fetch-dependencies",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Fetch dependencies for generated typescript classes.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Zoltu/solidity-typescript-generator.git"
   },
   "license": "Unlicense",
-  "main": "output-cjs/index.js",
+  "main": "./output-cjs/index.js",
   "exports": {
-    "import": "output-es/index.js",
-    "require": "output-cjs/index.js"
+    "import": "./output-es/index.js",
+    "require": "./output-cjs/index.js"
   },
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": "5.0.1",

--- a/fetch-dependencies/tsconfig.json
+++ b/fetch-dependencies/tsconfig.json
@@ -3,17 +3,18 @@
 		"module": "ES2015",
 		"target": "ES2020",
 		"moduleResolution": "node",
+		"rootDir": "source",
 		"sourceMap": true,
 		"inlineSources": true,
 		"declaration": true,
+		"declarationMap": true,
+		"noEmit": true,
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "output",
-		"rootDir": "source",
-		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ]
+		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ],
 	},
 	"include": [
 		"source/**/*.ts"

--- a/library/.npmignore
+++ b/library/.npmignore
@@ -1,2 +1,0 @@
-/node_modules/
-/tsconfig.json

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,10 +14,99 @@
       "resolved": "https://registry.npmjs.org/@zoltu/ethereum-crypto/-/ethereum-crypto-2.1.1.tgz",
       "integrity": "sha512-+Nt58vcVtp93UO3ZWt9PvUGMVKbJ4qRwWcFOmu+LkwvjSpBy6X51+sMiNkzgIaYGo/YpWWZ4hZCvluDSngOxHw=="
     },
+    "@zoltu/typescript-transformer-append-js-extension": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz",
+      "integrity": "sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "ts-node": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "ttypescript": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.10.tgz",
+      "integrity": "sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/library/package.json
+++ b/library/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@zoltu/solidity-typescript-generator",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Takes in a solidity file and generatese a set of TypeScript classes for interacting with the contract.",
-  "main": "output/index.js",
+  "main": "./output-cjs/index.js",
+  "exports": {
+    "import": "./output-es/index.js",
+    "require": "./output-cjs/index.js"
+  },
   "scripts": {
-    "build": "tsc",
+    "build": "ttsc --project tsconfig-es.json && ttsc --project tsconfig-cjs.json",
     "test": "cd ../tests && npm run test",
     "prepublishOnly": "npm run build && cd ../tests && npm run test && cd ../library && node --eval \"require('fs').copyFile('../README.md', 'README.md', error => {if(error) throw error})\"",
     "postpublish": "node --eval \"require('fs').unlink('README.md', error => {if(error) throw error})\""
@@ -20,10 +24,18 @@
   },
   "homepage": "https://github.com/Zoltu/solidity-typescript-generator#readme",
   "devDependencies": {
-    "typescript": "3.6.4"
+    "@zoltu/typescript-transformer-append-js-extension": "1.0.1",
+    "ts-node": "8.10.2",
+    "ttypescript": "1.5.10",
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "@zoltu/ethereum-abi-encoder": "5.0.1",
     "@zoltu/ethereum-crypto": "2.1.1"
-  }
+  },
+  "files": [
+    "source/",
+    "output-cjs",
+    "output-es"
+  ]
 }

--- a/library/tsconfig-cjs.json
+++ b/library/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"outDir": "output-cjs",
+		"noEmit": false,
+	},
+}

--- a/library/tsconfig-es.json
+++ b/library/tsconfig-es.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "ES2015",
+		"outDir": "output-es",
+		"noEmit": false,
+	},
+}

--- a/library/tsconfig.json
+++ b/library/tsconfig.json
@@ -1,16 +1,22 @@
 {
 	"compilerOptions": {
-		"target": "esnext",
-		"module": "commonjs",
-		"noImplicitAny": true,
-		"allowJs": false,
-		"strict": true,
-		"alwaysStrict": true,
-		"declaration": true,
-		"inlineSourceMap": true,
-		"inlineSources": true,
-		"lib": [ "es2018", "esnext.bigint" ],
+		"module": "ES2015",
+		"target": "ES2020",
+		"moduleResolution": "node",
 		"rootDir": "source",
-		"outDir": "output",
-	}
+		"sourceMap": true,
+		"inlineSources": true,
+		"declaration": true,
+		"declarationMap": true,
+		"noEmit": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"plugins": [ { "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true } ],
+	},
+	"include": [
+		"source/**/*.ts"
+	]
 }


### PR DESCRIPTION
`output/index.js` is not a valid exports path, it has to be `./output/index.js`.

While I was in here I added support for targeting ES Modules for the library, since NodeJS 14 now supports that.  Also added a missing readme to `browser-dependencies` and cleaned up some issues with the tsconfig files.